### PR TITLE
FIX: There is no 'validate' method

### DIFF
--- a/src/Providers/ValidatorPizzaProvider.php
+++ b/src/Providers/ValidatorPizzaProvider.php
@@ -23,7 +23,7 @@ class ValidatorPizzaProvider extends ServiceProvider
             dirname(__DIR__) . '/../migrations'
         );
 
-        Validator::extend('disposable_pizza', ValidatorRule::class . '@validate');
+        Validator::extend('disposable_pizza', ValidatorRule::class . '@passes');
     }
 
     /**


### PR DESCRIPTION
Reproduction steps:

1. On Controller:
```php
<?php

class TestController
{
	public function test(Request $request)
    {
        $validatedData = $request->validate([
            'email' => 'required|email|disposable_email',
            'password' => 'required',
        ]);
    }
}
```

2. Everytime we add `disposable_email` rule, we get this error:

```
call_user_func_array() expects parameter 1 to be a valid callback, class 'romanzipp\ValidatorPizza\Rules\DisposableEmailPizza' does not have a method 'validate'
```
